### PR TITLE
New helper method for generating SOAP fault

### DIFF
--- a/src/test/java/com/skjolberg/mockito/soap/SoapServiceFaultTest.java
+++ b/src/test/java/com/skjolberg/mockito/soap/SoapServiceFaultTest.java
@@ -4,6 +4,11 @@ import static com.skjolberg.mockito.soap.SoapServiceFault.createFault;
 
 import java.io.IOException;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlElement;
+
 import org.apache.cxf.helpers.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,15 +27,23 @@ public class SoapServiceFaultTest {
 		bankException.setCode("a");
 		bankException.setMessage("b");
 
-		createFault(bankException);		
+		createFault(bankException);
 	}
-	
+
+	@Test
+	public void createSoapFaultJAXBNoXmlRoot() {
+		NoXmlRootElement noXmlRoot = new NoXmlRootElement();
+		noXmlRoot.setFoo("bar");
+
+		createFault(noXmlRoot, NoXmlRootElement.class);
+	}
+
 	@Test
 	public void createSoapFaultNonJAXBException() {
 		exception.expect(Exception.class);
-		createFault(new Object());		
+		createFault(new Object());
 	}
-	
+
 	@Test
 	public void createSoapFaultString() throws IOException {
 		BankException bankException = new BankException();
@@ -43,6 +56,23 @@ public class SoapServiceFaultTest {
 	@Test
 	public void createSoapFaultNonXmlStringException() {
 		exception.expect(Exception.class);
-		createFault("abc");		
+		createFault("abc");
+	}
+
+	@XmlAccessorType(XmlAccessType.FIELD)
+	@XmlType(name = "", propOrder = { "foo" })
+	private static class NoXmlRootElement {
+
+		@XmlElement(required = true)
+		private String foo;
+
+		public String getFoo() {
+			return foo;
+		}
+
+		public void setFoo(String foo) {
+			this.foo = foo;
+		}
+
 	}
 }


### PR DESCRIPTION
Minor update, just added a helper method for generating a `SoapFault` with detail from autogenerated classes not having the `@XmlRootElement` annotation.

More context [here](https://community.oracle.com/blogs/kohsuke/2006/03/03/why-does-jaxb-put-xmlrootelement-sometimes-not-always).