### PR TITLE
Allow the usage of local:// transport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<commons-io.version>2.5</commons-io.version>
 
 		<cxf.version>3.1.16</cxf.version>
-		<spring.version>4.3.6.RELEASE</spring.version>
+		<spring.version>4.3.18.RELEASE</spring.version>
 		<logback.version>1.2.3</logback.version>
 		<slf4j.version>1.7.22</slf4j.version>
 		<build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
@@ -91,6 +91,11 @@
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-transports-http-jetty</artifactId>
+			<version>${cxf.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-transports-local</artifactId>
 			<version>${cxf.version}</version>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/skjolberg/mockito/soap/SoapServerRule.java
+++ b/src/main/java/com/skjolberg/mockito/soap/SoapServerRule.java
@@ -36,12 +36,9 @@ public class SoapServerRule extends SoapServiceRule {
 		if(address == null) {
 			throw new IllegalArgumentException("Expected address");
 		}
-		
-		try {
-			new URL(address);
-		} catch (MalformedURLException e) {
-			throw new IllegalArgumentException("Expected valid address: " + address, e);
-		}
+
+		assertValidAddress(address);
+
 		if(servers.containsKey(address)) {
 			throw new IllegalArgumentException("Server " + address + " already exists");
 		}
@@ -103,10 +100,21 @@ public class SoapServerRule extends SoapServiceRule {
 	public void reset() {
 		for (Entry<String, Server> entry : servers.entrySet()) {
 			entry.getValue().getDestination().shutdown();
-			
+
 			entry.getValue().destroy();
 		}
 		servers.clear();
 	}
 
+	private void assertValidAddress(String address) {
+		if (address != null && address.startsWith("local://")) {
+			return;
+		}
+
+		try {
+			new URL(address);
+		} catch (MalformedURLException e) {
+			throw new IllegalArgumentException("Expected valid address: " + address, e);
+		}
+	}
 }

--- a/src/test/java/com/skjolberg/mockito/soap/BankCustomerSoapEndpointRuleMtomTest.java
+++ b/src/test/java/com/skjolberg/mockito/soap/BankCustomerSoapEndpointRuleMtomTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.List;
 
@@ -15,6 +16,7 @@ import javax.activation.DataHandler;
 import javax.activation.DataSource;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.cxf.jaxrs.ext.multipart.InputStreamDataSource;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,7 +36,6 @@ import com.github.skjolber.bank.example.v1.BankCustomerServicePortType;
 import com.github.skjolber.bank.example.v1.BankRequestHeader;
 import com.github.skjolber.bank.example.v1.GetAccountsRequest;
 import com.github.skjolber.bank.example.v1.GetAccountsResponse;
-import com.sun.istack.ByteArrayDataSource;
 
 import static com.skjolberg.mockito.soap.SoapServiceRule.*;
 
@@ -115,7 +116,7 @@ public class BankCustomerSoapEndpointRuleMtomTest {
 		accountList.add("5678");
 
 		byte[] payload = new byte[] {0x00, 0x01};
-		DataSource source = new ByteArrayDataSource(payload, "application/octet-stream");
+		DataSource source = new InputStreamDataSource(new ByteArrayInputStream(payload), "application/octet-stream");
 		mockResponse.setCertificate(new DataHandler(source));
 		
 		when(bankServiceMock.getAccounts(any(GetAccountsRequest.class), any(BankRequestHeader.class))).thenReturn(mockResponse);

--- a/src/test/java/com/skjolberg/mockito/soap/BankCustomerSoapServerLocalTransportRuleTest.java
+++ b/src/test/java/com/skjolberg/mockito/soap/BankCustomerSoapServerLocalTransportRuleTest.java
@@ -1,0 +1,203 @@
+package com.skjolberg.mockito.soap;
+
+import com.github.skjolber.bank.example.v1.BankCustomerServicePortType;
+import com.github.skjolber.bank.example.v1.BankException;
+import com.github.skjolber.bank.example.v1.BankRequestHeader;
+import com.github.skjolber.bank.example.v1.CustomerException;
+import com.github.skjolber.bank.example.v1.GetAccountsRequest;
+import com.github.skjolber.bank.example.v1.GetAccountsResponse;
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.binding.soap.SoapFault;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.xml.namespace.QName;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.skjolberg.mockito.soap.SoapServiceFault.createFault;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations={"classpath:/spring/beans.xml"})
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@ActiveProfiles("dev3")
+public class BankCustomerSoapServerLocalTransportRuleTest {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Rule
+	public SoapServerRule soap = SoapServerRule.newInstance();
+
+	/**
+	 * Endpoint address (full url), typically pointing to localhost for unit testing, remote host otherwise.
+	 */
+
+	@Value("${bankcustomer.service}")
+	private String bankCustomerServiceAddress;
+
+	/**
+	 * Mock object proxied by SOAP service
+	 * 
+	 */
+	private BankCustomerServicePortType bankServiceMock; 
+
+	/**
+	 * Business code which calls the SOAP service via an autowired client
+	 * 
+	 */
+	@Autowired
+	private BankCustomerService bankCustomerService;
+
+	@Autowired
+	private Bus bus;
+
+
+	@Before
+	public void setup() {
+		// When running all tests combined, the tests in this class would fail.
+		// It seems that even though we are using @DirtiesContext, CXF will still keep state in
+		// a ThreadLocal. This should prevent that and will make these test pass.
+		BusFactory.setThreadDefaultBus(bus);
+
+		bankServiceMock = soap.mock(BankCustomerServicePortType.class, bankCustomerServiceAddress, Arrays.asList("classpath:wsdl/BankCustomerService.xsd"));
+	}
+	
+	/**
+	 * 
+	 * Webservice call which results in regular response returned to the client.
+	 * 
+	 */
+
+
+	@Test
+	public void processNormalSoapCall() throws Exception {
+
+		// add mock response
+		GetAccountsResponse mockResponse = new GetAccountsResponse();
+		List<String> accountList = mockResponse.getAccount();
+		accountList.add("1234");
+		accountList.add("5678");
+
+		when(bankServiceMock.getAccounts(any(GetAccountsRequest.class), any(BankRequestHeader.class))).thenReturn(mockResponse);
+
+		String customerNumber = "123456789"; // must be all numbers, if not schema validation fails
+		String secret = "abc";
+
+		// actually do something
+		GetAccountsResponse accounts = bankCustomerService.getAccounts(customerNumber, secret);
+
+		ArgumentCaptor<GetAccountsRequest> argument1 = ArgumentCaptor.forClass(GetAccountsRequest.class);
+		ArgumentCaptor<BankRequestHeader> argument2 = ArgumentCaptor.forClass(BankRequestHeader.class);
+		verify(bankServiceMock, times(1)).getAccounts(argument1.capture(), argument2.capture());
+
+		GetAccountsRequest request = argument1.getValue();
+		assertThat(request.getCustomerNumber(), is(customerNumber));
+
+		BankRequestHeader header = argument2.getValue();
+		assertThat(header.getSecret(), is(secret));
+
+		assertThat(accounts.getAccount(), is(accountList));
+	}
+	
+	/**
+	 * 
+	 * Webservice call which results in soap fault being returned to the client.
+	 * 
+	 */
+
+	@Test
+	public void processSoapCallWithException1() throws Exception {
+
+		// add mock response
+		GetAccountsResponse mockResponse = new GetAccountsResponse();
+		List<String> accountList = mockResponse.getAccount();
+		accountList.add("1234");
+		accountList.add("5678");
+
+		String errorCode = "myErrorCode";
+		String errorMessage = "myErrorMessage";
+
+		BankException bankException = new BankException();
+		bankException.setCode(errorCode);
+		bankException.setMessage(errorMessage);
+
+		SoapFault fault = createFault(bankException);
+
+		when(bankServiceMock.getAccounts(any(GetAccountsRequest.class), any(BankRequestHeader.class))).thenThrow(fault);
+
+		String customerNumber = "123456789";
+		String secret = "abc";
+
+		exception.expect(Exception.class);
+		 
+		// actually do something
+		bankCustomerService.getAccounts(customerNumber, secret);
+	}
+	
+	@Test
+	public void processSoapCallWithException2() throws Exception {
+
+		// add mock response
+		GetAccountsResponse mockResponse = new GetAccountsResponse();
+		List<String> accountList = mockResponse.getAccount();
+		accountList.add("1234");
+		accountList.add("5678");
+
+		String status = "DEAD";
+
+		CustomerException customerException = new CustomerException();
+		customerException.setStatus(status);
+
+		SoapFault fault = createFault(customerException, new QName("http://soap.spring.example.skjolberg.com/v1", "customerException"));
+
+		when(bankServiceMock.getAccounts(any(GetAccountsRequest.class), any(BankRequestHeader.class))).thenThrow(fault);
+
+		String customerNumber = "123456789";
+		String secret = "abc";
+
+		exception.expect(Exception.class);
+		 
+		// actually do something
+		bankCustomerService.getAccounts(customerNumber, secret);
+	}
+
+	@Test
+	public void processValiationException() throws Exception {
+		
+		// add mock response
+		GetAccountsResponse mockResponse = new GetAccountsResponse();
+		List<String> accountList = mockResponse.getAccount();
+		accountList.add("1234");
+		accountList.add("5678");
+
+		when(bankServiceMock.getAccounts(any(GetAccountsRequest.class), any(BankRequestHeader.class))).thenReturn(mockResponse);
+
+		String customerNumber = "abcdef"; // must be all numbers, if not schema validation fails
+		String secret = "abc";
+		
+		exception.expect(Exception.class); // unmarshalling error, the client does not accept the document as a request
+
+		// actually do something
+		bankCustomerService.getAccounts(customerNumber, secret);
+
+	}
+}

--- a/src/test/java/com/skjolberg/mockito/soap/BankCustomerSoapServerRuleMtomTest.java
+++ b/src/test/java/com/skjolberg/mockito/soap/BankCustomerSoapServerRuleMtomTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.List;
 
@@ -15,6 +16,7 @@ import javax.activation.DataHandler;
 import javax.activation.DataSource;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.cxf.jaxrs.ext.multipart.InputStreamDataSource;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,7 +36,6 @@ import com.github.skjolber.bank.example.v1.BankCustomerServicePortType;
 import com.github.skjolber.bank.example.v1.BankRequestHeader;
 import com.github.skjolber.bank.example.v1.GetAccountsRequest;
 import com.github.skjolber.bank.example.v1.GetAccountsResponse;
-import com.sun.istack.ByteArrayDataSource;
 import static com.skjolberg.mockito.soap.SoapServiceRule.*;
 
 /**
@@ -117,7 +118,7 @@ public class BankCustomerSoapServerRuleMtomTest {
 		accountList.add("5678");
 
 		byte[] payload = new byte[] {0x00, 0x01};
-		DataSource source = new ByteArrayDataSource(payload, "application/octet-stream");
+		DataSource source = new InputStreamDataSource(new ByteArrayInputStream(payload), "application/octet-stream");
 		mockResponse.setCertificate(new DataHandler(source));
 		
 		when(bankServiceMock.getAccounts(any(GetAccountsRequest.class), any(BankRequestHeader.class))).thenReturn(mockResponse);

--- a/src/test/resources/properties/dev3.properties
+++ b/src/test/resources/properties/dev3.properties
@@ -1,0 +1,10 @@
+################################################
+# SOAP endpoints
+################################################
+bankcustomer.service=local://selfservice/bank
+shopcustomer.service=local://selfservice/shop
+
+################################################
+# Logging configuration
+################################################
+cxf.logging.prettyprint=true

--- a/src/test/resources/spring/beans.xml
+++ b/src/test/resources/spring/beans.xml
@@ -63,4 +63,7 @@
 	<beans profile="dev2">
 		<context:property-placeholder location="classpath*:properties/dev2.properties"/>
 	</beans>
+	<beans profile="dev3">
+		<context:property-placeholder location="classpath*:properties/dev3.properties"/>
+	</beans>
 </beans>


### PR DESCRIPTION
Couple of remarks
* I duplicated the test for the 'non-local' transport. Wasn't sure if you wanted a lot of refactoring and/or your ideas regarding creating hierarchies in tests etc. Let me know.
* I updated Spring versions, but that is mostly there because I had problems getting the tests running as I explained in the issue (#7)
* Wasn't sure about removing the assert on URLs (i.e. `new URL()` with exception handling), so I went for the safe way of keeping it in.
* Maybe you want `<artifactId>cxf-rt-transports-local</artifactId>` to be `optional`? Let me know.

Lastly, but quite unrelated: I don't quite understand the `SoapProxy`, doesn't everything work just as well without it? Is it only used for converting mocked `Exceptions` to `Faults`?

Fixes #7