### PR TITLE
Fix Travis oraclejdk8 failure by switching to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 


### PR DESCRIPTION
Travis seems to no longer support oracleJDK8, switching to openjdk8 might help.