### PR TITLE
Bumps xcf to 4.1.0, spring to 6.1.14 and commons-io to 2.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.skjolber</groupId>
 	<artifactId>mockito-soap-cxf</artifactId>
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.0.2-SNAPSHOT</version>
 	<name>mockito-soap-cxf</name>
 	<description>SOAP web-service mocking utility for CXF</description>
 	<url>https://github.com/skjolber/mockito-soap-cxf</url>
@@ -18,10 +18,10 @@
 
 		<mockito.version>5.1.1</mockito.version>
 		<hamcrest.version>2.2</hamcrest.version>
-		<commons-io.version>2.11.0</commons-io.version>
+		<commons-io.version>2.14.0</commons-io.version>
 
-		<cxf.version>4.0.4</cxf.version>
-		<spring.version>6.0.8</spring.version>
+		<cxf.version>4.1.0</cxf.version>
+		<spring.version>6.1.14</spring.version>
     
 		<logback.version>1.2.13</logback.version>
 		<slf4j.version>1.7.32</slf4j.version>

--- a/src/test/resources/bindings.xml
+++ b/src/test/resources/bindings.xml
@@ -1,6 +1,6 @@
 <jaxws:bindings xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:jaxws="http://java.sun.com/xml/ns/jaxws"
-	xmlns:jaxb="http://java.sun.com/xml/ns/jaxb">
+	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:jaxws="https://jakarta.ee/xml/ns/jaxws"
+	xmlns:jxb="https://jakarta.ee/xml/ns/jaxb">
 	<!-- Turn off wrapper style Java method signature generation -->
 	<jaxws:enableWrapperStyle>false</jaxws:enableWrapperStyle>
 </jaxws:bindings>


### PR DESCRIPTION
Hey mate, I'm not quite sure whether your project is abandoned. But I used it successfully in a project of mine. I ran into issues with the included version of Jetty and had to bump the dependencies of your project. 

This is my first pull request so I am not quite sure what is required of me. Anyways, the changes are minimal. Maybe you get the time to check out my pull request. Cheers!